### PR TITLE
Post endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,6 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.7.5'
 
-gem "devise"
-gem "devise_token_auth"
-
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
 gem 'rails', '~> 6.1.6'
 # Use sqlite3 as the database for Active Record
@@ -26,6 +23,8 @@ gem 'puma', '~> 5.0'
 gem 'bootsnap', '>= 1.4.4', require: false
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
+gem "devise"
+gem "devise_token_auth"
 gem 'rack-cors'
 
 group :development, :test do

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::API
-        skip_before_action :verify_authenticity_token, if: :devise_controller?, raise: false
         include DeviseTokenAuth::Concerns::SetUserByToken
+        # skip_before_action :verify_authenticity_token, if: :devise_controller?, raise: false
         # skip_before_action :verify_authenticity_token, if: :devise_controller? # APIではCSRFチェックをしない
 end

--- a/app/controllers/v1/auth/registrations_controller.rb
+++ b/app/controllers/v1/auth/registrations_controller.rb
@@ -1,7 +1,0 @@
-class V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
-    private
-
-    def sign_up_params
-        params.permit(:name, :email, :password, :password_confirmation)
-    end
-end

--- a/app/controllers/v1/auth/registrations_controller.rb
+++ b/app/controllers/v1/auth/registrations_controller.rb
@@ -1,2 +1,7 @@
 class V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
+    private
+
+    def sign_up_params
+        params.permit(:name, :email, :password, :password_confirmation)
+    end
 end

--- a/app/controllers/v1/auth/sessions_controller.rb
+++ b/app/controllers/v1/auth/sessions_controller.rb
@@ -1,0 +1,9 @@
+class V1::Auth::SessionsController < ApplicationController
+    def index
+        if current_v1_user
+            render json: {is_login: true, data: current_v1_user}
+        else
+            render json: {is_login: false, message: "ユーザーが存在しません"}
+        end
+    end
+end

--- a/app/controllers/v1/posts_controller.rb
+++ b/app/controllers/v1/posts_controller.rb
@@ -35,16 +35,24 @@ module V1
             end
         end
 
-        def update
-            @post.update(post_params)
-            render json: {}, status: :no_content
+        def update # 現在ログイン中のユーザーの投稿であれば編集可能
+            if current_v1_user.id == @post.user_id
+                @post.update(post_params)
+                render json: {}, status: :no_content
+            else
+                render json: {}, status: :forbidden
+            end
         end
 
-        def destroy
-            @post.destroy
-            render json: {
-                post: @post
-            }, status: :no_content
+        def destroy # 現在ログイン中のユーザーの投稿であれば削除可能
+            if current_v1_user.id == @post.user_id
+                @post.destroy
+                render json: {
+                    post: @post
+                }, status: :no_content
+            else 
+                render json: {}, status: :forbidden
+            end
         end
 
         private

--- a/app/controllers/v1/posts_controller.rb
+++ b/app/controllers/v1/posts_controller.rb
@@ -1,10 +1,18 @@
 module V1
     class PostsController < ApplicationController
-        before_action :set_user
+        before_action :set_user, only: [:user_index]
         before_action :set_post, only: [:show, :update, :destroy]
+        before_action :authenticate_v1_user!
         
-        def index # 特定ユーザーのpost一覧を取得
+        def user_index # 特定ユーザーのpost一覧を取得
             posts = @user.posts
+            render json: {
+                posts: posts
+            }, status: :ok
+        end
+
+        def index # すべてのpost一覧を取得
+            posts = Post.all
             render json: {
                 posts: posts
             }, status: :ok
@@ -17,7 +25,7 @@ module V1
         end
 
         def create
-            post = @user.posts.build(post_params)
+            post = @current_v1_user.posts.build(post_params)
             if post.save!
                 render json: {
                     post: post

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,13 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins 'example.com'
-#
-#     resource '*',
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins 'localhost:3000'
+
+    resource '*',
+      headers: :any,
+      expose: ['access-token', 'expiry', 'token-type', 'uid', 'client'],
+      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+  end
+end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -42,11 +42,11 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names
-  # config.headers_names = {:'access-token' => 'access-token',
-  #                        :'client' => 'client',
-  #                        :'expiry' => 'expiry',
-  #                        :'uid' => 'uid',
-  #                        :'token-type' => 'token-type' }
+  config.headers_names = {:'access-token' => 'access-token',
+                         :'client' => 'client',
+                         :'expiry' => 'expiry',
+                         :'uid' => 'uid',
+                         :'token-type' => 'token-type' }
 
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -42,11 +42,11 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names
-  config.headers_names = {:'access-token' => 'access-token',
-                         :'client' => 'client',
-                         :'expiry' => 'expiry',
-                         :'uid' => 'uid',
-                         :'token-type' => 'token-type' }
+  # config.headers_names = {:'access-token' => 'access-token',
+  #                        :'client' => 'client',
+  #                        :'expiry' => 'expiry',
+  #                        :'uid' => 'uid',
+  #                        :'token-type' => 'token-type' }
 
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,9 @@ Rails.application.routes.draw do
   namespace :v1 do
     resources :posts
     mount_devise_token_auth_for 'User', at: 'auth'
+    namespace :auth do
+      get 'sessions', to: "sessions#index"
+    end
     resources :users do
       get 'posts', to: "posts#user_index"
       resources :best_times

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,9 @@
 Rails.application.routes.draw do
   namespace :v1 do
+    resources :posts
     mount_devise_token_auth_for 'User', at: 'auth'
     resources :users do
-      resources :posts do
-        resources :post_records
-      end
+      get 'posts', to: "posts#user_index"
       resources :best_times
       resources :objective
     end

--- a/spec/requests/auth/sessions_spec.rb
+++ b/spec/requests/auth/sessions_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Auth::Sessions", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
## 変更の概要
* PostモデルのAPIを設計する
* #5

## なぜこの変更をするのか
* 美しいWeb APIを実装する
* 認証機能をつける

## やったこと
* [x] エンドポイントの修正
* [x] ログイン中のユーザーにしか、投稿関連の処理ができないようにする
* [x] 練習の編集・削除は投稿を作ったユーザーでないとできないようにする 

## 課題
トークン認証に必要なuid、client、access-tokenをどう取得して、クライアントに保持させるかがまだ不明瞭だが、以下の記事が役に立ちそう。クライアント側を作る際に参考にする。