### PR TITLE
relate user/relationship #10

### DIFF
--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,0 +1,2 @@
+class Relationship < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,5 +7,8 @@ class User < ActiveRecord::Base
   has_many :best_times
   has_many :objectives
   has_many :teams
+  has_many :active_relationships, class_name:  "Relationship",
+                                  foreign_key: "follower_id",
+                                  dependent:   :destroy
   include DeviseTokenAuth::Concerns::User
 end

--- a/db/migrate/20220612133307_create_relationships.rb
+++ b/db/migrate/20220612133307_create_relationships.rb
@@ -1,0 +1,12 @@
+class CreateRelationships < ActiveRecord::Migration[6.1]
+  def change
+    create_table :relationships do |t|
+      t.integer :follower_id
+      t.integer :followed_id
+      t.timestamps
+    end
+    add_index :relationships, :follower_id
+    add_index :relationships, :followed_id
+    add_index :relationships, [:follower_id, :followed_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_25_053626) do
+ActiveRecord::Schema.define(version: 2022_06_12_133307) do
 
   create_table "best_times", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -67,6 +67,16 @@ ActiveRecord::Schema.define(version: 2022_05_25_053626) do
     t.float "warming_up_distance"
     t.float "cooling_down_distance"
     t.index ["user_id"], name: "index_posts_on_user_id"
+  end
+
+  create_table "relationships", force: :cascade do |t|
+    t.integer "follower_id"
+    t.integer "followed_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["followed_id"], name: "index_relationships_on_followed_id"
+    t.index ["follower_id", "followed_id"], name: "index_relationships_on_follower_id_and_followed_id", unique: true
+    t.index ["follower_id"], name: "index_relationships_on_follower_id"
   end
 
   create_table "teams", force: :cascade do |t|

--- a/spec/factories/relationships.rb
+++ b/spec/factories/relationships.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :relationship do
+    follower_id { 1 }
+    followed_id { 1 }
+  end
+end

--- a/spec/models/relationship_spec.rb
+++ b/spec/models/relationship_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Relationship, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 変更の概要
user同士のfollow-follower機能を実装した。

## なぜこの変更をするのか
* user同士がfollow、follower関係になれるようにするため

## やったこと
* [x] Relationshipモデルの追加
* [x] それに伴うルーティング、コントローラーのコーディング

## 課題
* 現状、follower, followingのリストに含まれるユーザーの情報が全て入ってしまっているので、ここを絞りたい。followerの投稿を引っ張ってきたいので、こちらはRailsチュートリアルの第14章最後を参考にする。

## 備考
* 今回のコードは[Railsチュートリアル第14章](https://railstutorial.jp/chapters/following_users?version=6.0#sec-relationship_user_associations)を参考に作成した。